### PR TITLE
qemu: Install git

### DIFF
--- a/qemu/Containerfile
+++ b/qemu/Containerfile
@@ -2,6 +2,7 @@ FROM docker.io/archlinux:base
 
 RUN pacman -Syyu --noconfirm && \
     pacman -S --noconfirm \
+        git \
         python \
         qemu-headless-arch-extra \
         zstd


### PR DESCRIPTION
The checkout action expects this:

https://github.com/ClangBuiltLinux/continuous-integration2/runs/4719061596?check_suite_focus=true

I was not expecting the actions to be run in the container but it seems
I misread GitHub's documentation.