### PR TITLE
qemu: Install python-yaml

### DIFF
--- a/qemu/Containerfile
+++ b/qemu/Containerfile
@@ -4,5 +4,6 @@ RUN pacman -Syyu --noconfirm && \
     pacman -S --noconfirm \
         git \
         python \
+        python-yaml \
         qemu-headless-arch-extra \
         zstd


### PR DESCRIPTION
I added a yaml import to utils.py in https://github.com/ClangBuiltLinux/continuous-integration2/pull/302.
utils.py is used within check_logs.py, which runs in this container so
we need this package there.

Link: https://github.com/ClangBuiltLinux/continuous-integration2/actions/runs/1855945810
