### PR TITLE
Test statically linked clang outside of Alpine Linux

### DIFF
--- a/.github/workflows/llvm-project-epoch-one.yml
+++ b/.github/workflows/llvm-project-epoch-one.yml
@@ -24,9 +24,13 @@ jobs:
         with:
           context: ./llvm-project
           file: ./llvm-project/Dockerfile.epoch1
+          load: true
           platforms: linux/amd64
-          push: ${{ github.repository_owner == 'ClangBuiltLinux' && github.event_name != 'pull_request' && github.ref_name == 'main' }}
           tags: |
             ghcr.io/clangbuiltlinux/llvm-project:stage2
       - name: Test statically linked clang
         run: bash ci/test-clang.sh
+      - name: Push image to ghcr.io
+        if: ${{ github.repository_owner == 'ClangBuiltLinux' && github.event_name != 'pull_request' && github.ref_name == 'main' }}
+        run: |
+          docker push ghcr.io/clangbuiltlinux/llvm-project:stage2

--- a/.github/workflows/llvm-project-epoch-one.yml
+++ b/.github/workflows/llvm-project-epoch-one.yml
@@ -28,3 +28,5 @@ jobs:
           push: ${{ github.repository_owner == 'ClangBuiltLinux' && github.event_name != 'pull_request' && github.ref_name == 'main' }}
           tags: |
             ghcr.io/clangbuiltlinux/llvm-project:stage2
+      - name: Test statically linked clang
+        run: bash ci/test-clang.sh

--- a/.github/workflows/llvm-project-epoch-two.yml
+++ b/.github/workflows/llvm-project-epoch-two.yml
@@ -24,9 +24,13 @@ jobs:
         with:
           context: ./llvm-project
           file: ./llvm-project/Dockerfile.epoch2
+          load: true
           platforms: linux/amd64
-          push: ${{ github.repository_owner == 'ClangBuiltLinux' && github.event_name != 'pull_request' && github.ref_name == 'main' }}
           tags: |
             ghcr.io/clangbuiltlinux/llvm-project:stage2
       - name: Test statically linked clang
         run: bash ci/test-clang.sh
+      - name: Push image to ghcr.io
+        if: ${{ github.repository_owner == 'ClangBuiltLinux' && github.event_name != 'pull_request' && github.ref_name == 'main' }}
+        run: |
+          docker push ghcr.io/clangbuiltlinux/llvm-project:stage2

--- a/.github/workflows/llvm-project-epoch-two.yml
+++ b/.github/workflows/llvm-project-epoch-two.yml
@@ -28,3 +28,5 @@ jobs:
           push: ${{ github.repository_owner == 'ClangBuiltLinux' && github.event_name != 'pull_request' && github.ref_name == 'main' }}
           tags: |
             ghcr.io/clangbuiltlinux/llvm-project:stage2
+      - name: Test statically linked clang
+        run: bash ci/test-clang.sh

--- a/ci/test-clang-docker.sh
+++ b/ci/test-clang-docker.sh
@@ -7,7 +7,8 @@ if [[ ! -d /repo ]]; then
     exit 1
 fi
 
-clang=/repo/toolchain/bin/clang
+CC=/repo/toolchain/bin/clang
+CXX=/repo/toolchain/bin/clang++
 hello_c=/repo/llvm-project/hello.c
 hello_cpp=/repo/llvm-project/hello.cpp
 hello_exe=/tmp/hello
@@ -15,7 +16,7 @@ host_arch=$(uname -m)
 
 # Print clang information, which makes sure it can run
 echo "[+] Testing 'clang --version'"
-"$clang" --version
+"$CC" --version
 
 case "$(source /usr/lib/os-release; echo "$ID")" in
     fedora)
@@ -41,18 +42,18 @@ esac
 ########
 
 echo "[+] Testing dynamically linking hello.c against musl"
-"$clang" "${musl_cc_flags[@]}" -o "$hello_exe" "$hello_c"
+"$CC" "${musl_cc_flags[@]}" -o "$hello_exe" "$hello_c"
 "$hello_exe"
 
 echo "[+] Testing statically linking hello.c against musl"
-"$clang" "${musl_cc_flags[@]}" -static -o "$hello_exe" "$hello_c"
+"$CC" "${musl_cc_flags[@]}" -static -o "$hello_exe" "$hello_c"
 "$hello_exe"
 
 echo "[+] Testing dynamically linking hello.cpp against musl"
 # --rpath to avoid having to pull in libc++ and libunwind from distribution
-"$clang"++ "${musl_cc_flags[@]}" -Wl,--rpath=/repo/toolchain/lib/"$host_arch"-alpine-linux-musl -o "$hello_exe" "$hello_cpp"
+"$CXX" "${musl_cc_flags[@]}" -Wl,--rpath=/repo/toolchain/lib/"$host_arch"-alpine-linux-musl -o "$hello_exe" "$hello_cpp"
 "$hello_exe"
 
 echo "[+] Testing statically linking hello.cpp against musl"
-"$clang"++ "${musl_cc_flags[@]}" -static -lc++abi -o "$hello_exe" "$hello_cpp"
+"$CXX" "${musl_cc_flags[@]}" -static -lc++abi -o "$hello_exe" "$hello_cpp"
 "$hello_exe"

--- a/ci/test-clang-docker.sh
+++ b/ci/test-clang-docker.sh
@@ -20,11 +20,7 @@ echo "[+] Testing 'clang --version'"
 
 case "$(source /usr/lib/os-release; echo "$ID")" in
     arch)
-        musl_cc_flags=(
-            -B /usr/lib/musl/lib     # Scrt1.o, crti.o, crtn.o
-            -I /usr/lib/musl/include # stdio.h
-            -L /usr/lib/musl/lib     # -lc
-        )
+        musl_cc_flags=(--sysroot=/usr/lib/musl)
 
         echo "[+] Updating OS and installing musl"
         pacman -Syyu --noconfirm musl

--- a/ci/test-clang-docker.sh
+++ b/ci/test-clang-docker.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -eu
+
+if [[ ! -d /repo ]]; then
+    echo "[-] This script needs to be run within Docker! Use test-clang.sh instead."
+    exit 1
+fi
+
+clang=/repo/toolchain/bin/clang
+hello_c=/repo/llvm-project/hello.c
+hello_cpp=/repo/llvm-project/hello.cpp
+hello_exe=/tmp/hello
+host_arch=$(uname -m)
+
+# Print clang information, which makes sure it can run
+echo "[+] Testing 'clang --version'"
+"$clang" --version
+
+case "$(source /usr/lib/os-release; echo "$ID")" in
+    fedora)
+        musl_cc_flags=(
+            -B /usr/"$host_arch"-linux-musl/lib64   # Scrt1.o, crti.o, crtn.o
+            -I /usr/"$host_arch"-linux-musl/include # stdio.h
+            -L /usr/"$host_arch"-linux-musl/lib64   # -lc
+        )
+
+        echo "[+] Updating OS"
+        dnf update -qy
+
+        echo "[+] Installing musl"
+        dnf install -qy \
+            musl-devel \
+            musl-libc \
+            musl-libc-static
+        ;;
+esac
+
+########
+# MUSL #
+########
+
+echo "[+] Testing dynamically linking hello.c against musl"
+"$clang" "${musl_cc_flags[@]}" -o "$hello_exe" "$hello_c"
+"$hello_exe"
+
+echo "[+] Testing statically linking hello.c against musl"
+"$clang" "${musl_cc_flags[@]}" -static -o "$hello_exe" "$hello_c"
+"$hello_exe"
+
+echo "[+] Testing dynamically linking hello.cpp against musl"
+# --rpath to avoid having to pull in libc++ and libunwind from distribution
+"$clang"++ "${musl_cc_flags[@]}" -Wl,--rpath=/repo/toolchain/lib/"$host_arch"-alpine-linux-musl -o "$hello_exe" "$hello_cpp"
+"$hello_exe"
+
+echo "[+] Testing statically linking hello.cpp against musl"
+"$clang"++ "${musl_cc_flags[@]}" -static -lc++abi -o "$hello_exe" "$hello_cpp"
+"$hello_exe"

--- a/ci/test-clang-docker.sh
+++ b/ci/test-clang-docker.sh
@@ -19,6 +19,17 @@ echo "[+] Testing 'clang --version'"
 "$CC" --version
 
 case "$(source /usr/lib/os-release; echo "$ID")" in
+    arch)
+        musl_cc_flags=(
+            -B /usr/lib/musl/lib     # Scrt1.o, crti.o, crtn.o
+            -I /usr/lib/musl/include # stdio.h
+            -L /usr/lib/musl/lib     # -lc
+        )
+
+        echo "[+] Updating OS and installing musl"
+        pacman -Syyu --noconfirm musl
+        ;;
+
     fedora)
         musl_cc_flags=(
             -B /usr/"$host_arch"-linux-musl/lib64   # Scrt1.o, crti.o, crtn.o

--- a/ci/test-clang-docker.sh
+++ b/ci/test-clang-docker.sh
@@ -49,10 +49,14 @@ echo "[+] Testing statically linking hello.c against musl"
 "$CC" "${musl_cc_flags[@]}" -static -o "$hello_exe" "$hello_c"
 "$hello_exe"
 
-echo "[+] Testing dynamically linking hello.cpp against musl"
+echo "[+] Testing dynamically linking hello.cpp against musl ('--rpath')"
 # --rpath to avoid having to pull in libc++ and libunwind from distribution
 "$CXX" "${musl_cc_flags[@]}" -Wl,--rpath=/repo/toolchain/lib/"$host_arch"-alpine-linux-musl -o "$hello_exe" "$hello_cpp"
 "$hello_exe"
+
+echo "[+] Testing dynamically linking hello.cpp against musl ('LD_LIBRARY_PATH')"
+"$CXX" "${musl_cc_flags[@]}" -o "$hello_exe" "$hello_cpp"
+LD_LIBRARY_PATH=/lib:/repo/toolchain/lib/"$host_arch"-alpine-linux-musl "$hello_exe"
 
 echo "[+] Testing statically linking hello.cpp against musl"
 "$CXX" "${musl_cc_flags[@]}" -static -lc++abi -o "$hello_exe" "$hello_cpp"

--- a/ci/test-clang.sh
+++ b/ci/test-clang.sh
@@ -27,5 +27,5 @@ for docker_image in "${docker_images[@]}"; do
     echo "[+] Updating '$docker_image'"
     docker pull "$docker_image"
     echo "[+] Testing clang in '$docker_image' container"
-    docker run --rm -v "$rootdir":/repo:ro "$docker_image" bash /repo/ci/test-clang-docker.sh
+    docker run --rm --volume "$rootdir":/repo:ro "$docker_image" bash /repo/ci/test-clang-docker.sh
 done

--- a/ci/test-clang.sh
+++ b/ci/test-clang.sh
@@ -11,10 +11,10 @@ toolchain=$rootdir/toolchain
 # Pull toolchain out of container
 echo "[+] Downloading toolchain from container"
 docker create --name llvm-project ghcr.io/clangbuiltlinux/llvm-project:stage2
-mkdir -p "$toolchain"/{bin,include,lib}
-docker cp llvm-project:/usr/local/bin/. "$toolchain"/bin
-docker cp llvm-project:/usr/local/include/. "$toolchain"/include
-docker cp llvm-project:/usr/local/lib/. "$toolchain"/lib
+mkdir "$toolchain"
+docker cp llvm-project:/usr/local/bin "$toolchain"
+docker cp llvm-project:/usr/local/include "$toolchain"
+docker cp llvm-project:/usr/local/lib "$toolchain"
 echo "[+] Cleaning up container"
 docker rm llvm-project
 

--- a/ci/test-clang.sh
+++ b/ci/test-clang.sh
@@ -23,7 +23,7 @@ docker rm llvm-project
 docker_images=(
     docker.io/fedora:latest
 )
-# Arch Linux is x86_64-only
+# Arch Linux is an x86_64-only distribution
 [[ $(uname -m) = "x86_64" ]] && docker_images+=(docker.io/archlinux:latest)
 for docker_image in "${docker_images[@]}"; do
     echo "[+] Updating '$docker_image'"

--- a/ci/test-clang.sh
+++ b/ci/test-clang.sh
@@ -27,5 +27,9 @@ for docker_image in "${docker_images[@]}"; do
     echo "[+] Updating '$docker_image'"
     docker pull "$docker_image"
     echo "[+] Testing clang in '$docker_image' container"
-    docker run --rm --volume "$rootdir":/repo:ro "$docker_image" bash /repo/ci/test-clang-docker.sh
+    docker run \
+        --rm \
+        --volume "$rootdir":/repo:ro \
+        "$docker_image" \
+        bash /repo/ci/test-clang-docker.sh
 done

--- a/ci/test-clang.sh
+++ b/ci/test-clang.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -eu
+
+trap 'rm -fr "$toolchain"' EXIT
+
+# Set up workspace
+rootdir=${GITHUB_WORKSPACE:-$(dirname "$(dirname "$(realpath "$0")")")}
+toolchain=$rootdir/toolchain
+
+# Pull toolchain out of container
+echo "[+] Downloading toolchain from container"
+docker create --name llvm-project ghcr.io/clangbuiltlinux/llvm-project:stage2
+mkdir -p "$toolchain"/{bin,include,lib}
+docker cp llvm-project:/usr/local/bin/. "$toolchain"/bin
+docker cp llvm-project:/usr/local/include/. "$toolchain"/include
+docker cp llvm-project:/usr/local/lib/. "$toolchain"/lib
+echo "[+] Cleaning up container"
+docker rm llvm-project
+
+# Test toolchain in Docker images so that the environment is consistent,
+# regardless of runners.
+docker_images=(
+    docker.io/fedora:latest
+)
+for docker_image in "${docker_images[@]}"; do
+    echo "[+] Updating '$docker_image'"
+    docker pull "$docker_image"
+    echo "[+] Testing clang in '$docker_image' container"
+    docker run --rm -v "$rootdir":/repo:ro "$docker_image" bash /repo/ci/test-clang-docker.sh
+done

--- a/ci/test-clang.sh
+++ b/ci/test-clang.sh
@@ -23,6 +23,8 @@ docker rm llvm-project
 docker_images=(
     docker.io/fedora:latest
 )
+# Arch Linux is x86_64-only
+[[ $(uname -m) = "x86_64" ]] && docker_images+=(docker.io/archlinux:latest)
 for docker_image in "${docker_images[@]}"; do
     echo "[+] Updating '$docker_image'"
     docker pull "$docker_image"


### PR DESCRIPTION
We should verify that we can use the toolchain produced in Alpine Linux
on other distributions as part of the continuous integration pipeline.

We download the toolchain out of the container, mount it into the
containers that we want to test it in, and test dynamically and
statically linking hello.{c,cpp} with musl. Eventually, glibc should be
tested but there are issues during the link phase.

Initially, the only container that is being tested is Fedora. However, I
intentionally wrote this in such a way that we should be able to use
this across multiple distributions and test more than just
hello.{c,cpp}.

This was tested on a self-hosted GitHub Actions runner:

https://github.com/nathanchance/containers/actions/runs/2387476728
