### PR TITLE
github: Move to a composite action for llvm-project builds

### DIFF
--- a/.github/actions/build-test-llvm-project/action.yml
+++ b/.github/actions/build-test-llvm-project/action.yml
@@ -1,0 +1,32 @@
+name: Build and test llvm-project
+description: Build and test an llvm-project container
+
+inputs:
+  file:
+    description: Dockerfile to build the container from
+    required: true
+  platforms:
+    description: Platforms to build the container for
+    required: true
+  tags:
+    description: Tags to use for the final container
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build llvm-project
+      uses: docker/build-push-action@v3
+      with:
+        context: ./llvm-project
+        file: ./llvm-project/${{ inputs.file }}
+        load: true
+        platforms: ${{ inputs.platform }}
+        tags: ${{ inputs.tags }}
+
+    - name: Test statically linked clang
+      shell: bash
+      run: ci/test-clang.sh ${{ inputs.tags }}

--- a/.github/workflows/llvm-project-epoch-one.yml
+++ b/.github/workflows/llvm-project-epoch-one.yml
@@ -11,21 +11,12 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Build
-        uses: docker/build-push-action@v3
+      - name: Build and test llvm-project
+        uses: ./.github/actions/build-test-llvm-project
         with:
-          context: ./llvm-project
-          file: ./llvm-project/Dockerfile.epoch1
-          load: true
+          file: Dockerfile.epoch1
           platforms: linux/amd64
-          tags: |
-            ghcr.io/clangbuiltlinux/llvm-project:stage2
-
-      - name: Test statically linked clang
-        run: bash ci/test-clang.sh
+          tags: ghcr.io/clangbuiltlinux/llvm-project:stage2
 
       - name: Login to ghcr.io
         if: ${{ github.repository_owner == 'ClangBuiltLinux' && github.event_name != 'pull_request' && github.ref_name == 'main' }}

--- a/.github/workflows/llvm-project-epoch-two.yml
+++ b/.github/workflows/llvm-project-epoch-two.yml
@@ -11,21 +11,12 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
-      - name: Build
-        uses: docker/build-push-action@v3
+      - name: Build and test llvm-project
+        uses: ./.github/actions/build-test-llvm-project
         with:
-          context: ./llvm-project
-          file: ./llvm-project/Dockerfile.epoch2
-          load: true
+          file: Dockerfile.epoch2
           platforms: linux/amd64
-          tags: |
-            ghcr.io/clangbuiltlinux/llvm-project:stage2
-
-      - name: Test statically linked clang
-        run: bash ci/test-clang.sh
+          tags: ghcr.io/clangbuiltlinux/llvm-project:stage2
 
       - name: Login to ghcr.io
         if: ${{ github.repository_owner == 'ClangBuiltLinux' && github.event_name != 'pull_request' && github.ref_name == 'main' }}

--- a/ci/test-clang.sh
+++ b/ci/test-clang.sh
@@ -10,7 +10,7 @@ toolchain=$rootdir/toolchain
 
 # Pull toolchain out of container
 echo "[+] Downloading toolchain from container"
-docker create --name llvm-project ghcr.io/clangbuiltlinux/llvm-project:stage2
+docker create --name llvm-project "$1"
 mkdir "$toolchain"
 docker cp llvm-project:/usr/local/bin "$toolchain"
 docker cp llvm-project:/usr/local/include "$toolchain"


### PR DESCRIPTION
This allows us to share the steps to build the container between the
different epoch workflows, which helps keeps things in sync as much as
possible.

As part of this change, pull the hardcoded tag out of test-clang.sh, so
that in the future, other stages can be tested.
