### PR TITLE
Upload toolchain tarball when build is successful

### DIFF
--- a/.github/actions/build-test-llvm-project/action.yml
+++ b/.github/actions/build-test-llvm-project/action.yml
@@ -30,3 +30,9 @@ runs:
     - name: Test statically linked clang
       shell: bash
       run: ci/test-clang.sh ${{ inputs.tags }}
+
+    - name: Upload toolchain tarball
+      uses: actions/upload-artifact@v3
+      with:
+        if-no-files-found: error
+        path: toolchain.tar.zst

--- a/ci/test-clang.sh
+++ b/ci/test-clang.sh
@@ -35,3 +35,13 @@ for docker_image in "${docker_images[@]}"; do
         "$docker_image" \
         bash /repo/ci/test-clang-docker.sh
 done
+
+# Tar up the toolchain so it can be uploaded via GitHub Actions
+echo "[+] Creating toolchain archive"
+tar \
+    --create \
+    --directory "$toolchain" \
+    --file "$rootdir"/toolchain.tar.zst \
+    --verbose \
+    --zstd \
+    bin include lib


### PR DESCRIPTION
Currently, the toolchain is only available through a Docker image, which
is quite large and only uploaded from our organization. For testing, it
would be useful to have some way to build in CI and pull down the result
without having to upload a new image to the container registry.

Take advantage of the upload-artifact action, which allows us to create
then upload the toolchain tarball so it can be downloaded after a
successful run. Because we are a public repository, we do not have any
usage limits with storage.
