### PR TITLE
llvm-project: Specify registry for Alpine image

### DIFF
--- a/llvm-project/Dockerfile.epoch1
+++ b/llvm-project/Dockerfile.epoch1
@@ -1,9 +1,9 @@
-FROM alpine:edge AS source
+FROM docker.io/alpine:edge AS source
 RUN wget --no-clobber \
   https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.1/llvm-project-14.0.1.src.tar.xz
 
 # Stage one
-FROM alpine:edge AS stage_one
+FROM docker.io/alpine:edge AS stage_one
 
 COPY --from=source llvm-project-14.0.1.src.tar.xz /
 RUN tar xf llvm-project-14.0.1.src.tar.xz && \
@@ -65,7 +65,7 @@ RUN ninja -C ${LLVM_BUILD_DIR} install-llvm-ar
 ### START STAGE2
 
 # STAGE2 goal, build WITHOUT apk add
-FROM alpine:edge as stage_two
+FROM docker.io/alpine:edge as stage_two
 COPY --from=stage_one /usr/local/bin /usr/local/bin
 COPY --from=stage_one /usr/local/lib /usr/local/lib
 COPY --from=stage_one /usr/local/include /usr/local/include

--- a/llvm-project/Dockerfile.epoch2
+++ b/llvm-project/Dockerfile.epoch2
@@ -1,11 +1,11 @@
-FROM alpine:edge AS source
+FROM docker.io/alpine:edge AS source
 RUN wget --no-clobber \
   https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.1/llvm-project-14.0.1.src.tar.xz
 
 ### START STAGE2
 
 FROM ghcr.io/clangbuiltlinux/llvm-project:stage2 as prev_epoch
-FROM alpine:edge as stage_two
+FROM docker.io/alpine:edge as stage_two
 
 COPY --from=prev_epoch /usr/local/bin /usr/local/bin
 COPY --from=prev_epoch /usr/local/lib /usr/local/lib

--- a/llvm-project/Dockerfile.epoch3
+++ b/llvm-project/Dockerfile.epoch3
@@ -1,13 +1,13 @@
 ARG base=ghcr.io/clangbuiltlinux/llvm-project:stage2
 
-FROM alpine:edge AS source
+FROM docker.io/alpine:edge AS source
 RUN wget --no-verbose https://git.kernel.org/torvalds/t/linux-5.18-rc6.tar.gz
 RUN wget --no-verbose https://musl.libc.org/releases/musl-1.2.3.tar.gz
 RUN wget --no-verbose https://zlib.net/zlib-1.2.12.tar.gz
 RUN wget --no-verbose https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.1/llvm-project-14.0.1.src.tar.xz
 
 FROM ${base} AS stage2
-FROM alpine:edge AS stage3
+FROM docker.io/alpine:edge AS stage3
 
 ### BEGIN STAGE3
 


### PR DESCRIPTION
On certain distributions, such as Arch Linux, there is not a default
registries list for `podman`, meaning `alpine:edge` won't resolve to
anything. Add the registry explicitly, which allows everything to work
properly, regardless of the user's configuration.
