### PR TITLE
ci/test-clang.sh: Skip toolchain archive creation when run locally

### DIFF
--- a/ci/test-clang.sh
+++ b/ci/test-clang.sh
@@ -37,11 +37,13 @@ for docker_image in "${docker_images[@]}"; do
 done
 
 # Tar up the toolchain so it can be uploaded via GitHub Actions
-echo "[+] Creating toolchain archive"
-tar \
-    --create \
-    --directory "$toolchain" \
-    --file "$rootdir"/toolchain.tar.zst \
-    --verbose \
-    --zstd \
-    bin include lib
+if [[ -n ${GITHUB_ACTIONS:-} ]]; then
+    echo "[+] Creating toolchain archive"
+    tar \
+        --create \
+        --directory "$toolchain" \
+        --file "$rootdir"/toolchain.tar.zst \
+        --verbose \
+        --zstd \
+        bin include lib
+fi


### PR DESCRIPTION
While this script was only designed to be run in CI, it works well
locally, aside from the fact that it always creates a toolchain archive,
which makes little sense when testing locally, as the image will be
easily accessible.

Only generate this tarball when run in GitHub Actions.
