### PR TITLE
Add support for arm64 to llvm-project

### DIFF
--- a/.github/actions/build-test-llvm-project/action.yml
+++ b/.github/actions/build-test-llvm-project/action.yml
@@ -2,6 +2,9 @@ name: Build and test llvm-project
 description: Build and test an llvm-project container
 
 inputs:
+  arch:
+    description: Architecture to build containers for
+    required: true
   file:
     description: Dockerfile to build the container from
     required: true
@@ -36,4 +39,5 @@ runs:
       uses: actions/upload-artifact@v3
       with:
         if-no-files-found: error
+        name: artifact-${{ inputs.arch }}
         path: toolchain.tar.zst

--- a/.github/workflows/llvm-project-epoch-one.yml
+++ b/.github/workflows/llvm-project-epoch-one.yml
@@ -4,9 +4,17 @@ on: workflow_dispatch
 jobs:
   epoch1:
     name: stage 1 and 2
-    runs-on: [self-hosted, x64]
+    runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            os: [self-hosted, arm64]
+            platforms: linux/arm64
+          - arch: x86_64
+            os: [self-hosted, x64]
+            platforms: linux/amd64
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -14,8 +22,9 @@ jobs:
       - name: Build and test llvm-project
         uses: ./.github/actions/build-test-llvm-project
         with:
+          arch: ${{ matrix.arch }}
           file: Dockerfile.epoch1
-          platforms: linux/amd64
+          platforms: ${{ matrix.platforms }}
           tags: ghcr.io/clangbuiltlinux/llvm-project:stage2
 
       - name: Login to ghcr.io

--- a/.github/workflows/llvm-project-epoch-three.yml
+++ b/.github/workflows/llvm-project-epoch-three.yml
@@ -4,9 +4,17 @@ on: workflow_dispatch
 jobs:
   epoch3:
     name: stage 3
-    runs-on: [self-hosted, x64]
+    runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            os: [self-hosted, arm64]
+            platforms: linux/arm64
+          - arch: x86_64
+            os: [self-hosted, x64]
+            platforms: linux/amd64
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/llvm-project-epoch-two.yml
+++ b/.github/workflows/llvm-project-epoch-two.yml
@@ -4,9 +4,17 @@ on: workflow_dispatch
 jobs:
   epoch2:
     name: stage 2
-    runs-on: [self-hosted, x64]
+    runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            os: [self-hosted, arm64]
+            platforms: linux/arm64
+          - arch: x86_64
+            os: [self-hosted, x64]
+            platforms: linux/amd64
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -14,8 +22,9 @@ jobs:
       - name: Build and test llvm-project
         uses: ./.github/actions/build-test-llvm-project
         with:
+          arch: ${{ matrix.arch }}
           file: Dockerfile.epoch2
-          platforms: linux/amd64
+          platforms: ${{ matrix.platforms }}
           tags: ghcr.io/clangbuiltlinux/llvm-project:stage2
 
       - name: Login to ghcr.io

--- a/llvm-project/Dockerfile.epoch1
+++ b/llvm-project/Dockerfile.epoch1
@@ -43,6 +43,7 @@ ARG LLVM_BUILD_DIR=llvm-project/llvm/build
 RUN cmake \
   -B ${LLVM_BUILD_DIR} \
   -C llvm-project/stage1.cmake \
+  -DLLVM_DEFAULT_TARGET_TRIPLE=$(clang -print-target-triple) \
   -S llvm-project/llvm \
   -G Ninja
 
@@ -76,7 +77,7 @@ COPY hello.c hello.cpp /
 # symlinking nonsense at the start of other builds.
 RUN cd /usr/lib/ && \
   for library in libc++abi.so.1 libc++.a libc++abi.a libc++.so.1 libunwind.so.1 libunwind.a; \
-    do ln -s "/usr/local/lib/x86_64-alpine-linux-musl/${library}" . ; \
+    do ln -sv /usr/local/lib/$(uname -m)-alpine-linux-musl/${library} .; \
   done
 
 # The stage 1 build of clang/lld/other binaries still depends on libstdc++.
@@ -118,6 +119,7 @@ ARG LLVM_BUILD_DIR=llvm-project/llvm/build
 RUN cmake \
   -B ${LLVM_BUILD_DIR} \
   -C llvm-project/stage2.cmake \
+  -DLLVM_DEFAULT_TARGET_TRIPLE=$(clang -print-target-triple) \
   -S llvm-project/llvm \
   -G Ninja
 

--- a/llvm-project/Dockerfile.epoch1
+++ b/llvm-project/Dockerfile.epoch1
@@ -43,7 +43,7 @@ ARG LLVM_BUILD_DIR=llvm-project/llvm/build
 RUN cmake \
   -B ${LLVM_BUILD_DIR} \
   -C llvm-project/stage1.cmake \
-  -DLLVM_DEFAULT_TARGET_TRIPLE=$(clang -print-target-triple) \
+  -D LLVM_DEFAULT_TARGET_TRIPLE=$(clang -print-target-triple) \
   -S llvm-project/llvm \
   -G Ninja
 
@@ -119,7 +119,7 @@ ARG LLVM_BUILD_DIR=llvm-project/llvm/build
 RUN cmake \
   -B ${LLVM_BUILD_DIR} \
   -C llvm-project/stage2.cmake \
-  -DLLVM_DEFAULT_TARGET_TRIPLE=$(clang -print-target-triple) \
+  -D LLVM_DEFAULT_TARGET_TRIPLE=$(clang -print-target-triple) \
   -S llvm-project/llvm \
   -G Ninja
 

--- a/llvm-project/Dockerfile.epoch2
+++ b/llvm-project/Dockerfile.epoch2
@@ -42,7 +42,7 @@ ARG LLVM_BUILD_DIR=llvm-project/llvm/build
 RUN cmake \
   -B ${LLVM_BUILD_DIR} \
   -C llvm-project/stage2.cmake \
-  -DLLVM_DEFAULT_TARGET_TRIPLE=$(clang -print-target-triple) \
+  -D LLVM_DEFAULT_TARGET_TRIPLE=$(clang -print-target-triple) \
   -S llvm-project/llvm \
   -G Ninja
 

--- a/llvm-project/Dockerfile.epoch2
+++ b/llvm-project/Dockerfile.epoch2
@@ -16,7 +16,7 @@ COPY --from=prev_epoch /usr/local/include /usr/local/include
 # symlinking nonsense at the start of other builds.
 RUN cd /usr/lib/ && \
   for library in libc++abi.so.1 libc++.a libc++abi.a libc++.so.1 libunwind.so.1 libunwind.a; \
-    do ln -s "/usr/local/lib/x86_64-alpine-linux-musl/${library}" . ; \
+    do ln -sv /usr/local/lib/$(uname -m)-alpine-linux-musl/${library} .; \
   done
 
 RUN apk add musl-dev
@@ -42,6 +42,7 @@ ARG LLVM_BUILD_DIR=llvm-project/llvm/build
 RUN cmake \
   -B ${LLVM_BUILD_DIR} \
   -C llvm-project/stage2.cmake \
+  -DLLVM_DEFAULT_TARGET_TRIPLE=$(clang -print-target-triple) \
   -S llvm-project/llvm \
   -G Ninja
 

--- a/llvm-project/Dockerfile.epoch3
+++ b/llvm-project/Dockerfile.epoch3
@@ -16,7 +16,7 @@ COPY --from=stage2 /usr/local/lib /usr/local/lib
 COPY --from=stage2 /usr/local/include /usr/local/include
 RUN cd /usr/lib/ && \
   for library in libc++abi.so.1 libc++.a libc++abi.a libc++.so.1 libunwind.so.1 libunwind.a; \
-    do ln -s "/usr/local/lib/x86_64-alpine-linux-musl/${library}" . ; \
+    do ln -s "/usr/local/lib/$(uname -m)-alpine-linux-musl/${library}" . ; \
   done
 
 ### Linux
@@ -70,6 +70,7 @@ ARG LLVM_BUILD_DIR=llvm-project/llvm/build
 RUN cmake \
   -B ${LLVM_BUILD_DIR} \
   -C llvm-project/stage3.cmake \
+  -DLLVM_DEFAULT_TARGET_TRIPLE=$(clang -print-target-triple) \
   -S llvm-project/llvm \
   -G Ninja
 RUN ninja -C ${LLVM_BUILD_DIR} install-clang install-lld

--- a/llvm-project/Dockerfile.epoch3
+++ b/llvm-project/Dockerfile.epoch3
@@ -70,7 +70,7 @@ ARG LLVM_BUILD_DIR=llvm-project/llvm/build
 RUN cmake \
   -B ${LLVM_BUILD_DIR} \
   -C llvm-project/stage3.cmake \
-  -DLLVM_DEFAULT_TARGET_TRIPLE=$(clang -print-target-triple) \
+  -D LLVM_DEFAULT_TARGET_TRIPLE=$(clang -print-target-triple) \
   -S llvm-project/llvm \
   -G Ninja
 RUN ninja -C ${LLVM_BUILD_DIR} install-clang install-lld

--- a/llvm-project/stage1.cmake
+++ b/llvm-project/stage1.cmake
@@ -8,12 +8,6 @@ set(CMAKE_BUILD_TYPE "Release" CACHE STRING "")
 set(CMAKE_CXX_COMPILER "/usr/bin/clang++" CACHE FILEPATH "")
 set(CMAKE_C_COMPILER "/usr/bin/clang" CACHE FILEPATH "")
 
-# Set the default target triple to match the host.
-# TODO: passing in the value of $(clang -print-multiarch) causes failures.
-# It seems that alpine clang's default target triple is x86_64-linux-gnu.
-# Perhaps missing alpine in the triple causes some incompatibility?
-set(LLVM_DEFAULT_TARGET_TRIPLE "x86_64-alpine-linux-musl" CACHE STRING "")
-
 # Use Alpine's lld as the stage0 linker to link everything.
 set(LLVM_ENABLE_LLD ON CACHE BOOL "")
 

--- a/llvm-project/stage2.cmake
+++ b/llvm-project/stage2.cmake
@@ -26,12 +26,6 @@ set(CMAKE_C_COMPILER "/usr/local/bin/clang" CACHE FILEPATH "")
 set(CMAKE_EXE_LINKER_FLAGS "--unwindlib=libunwind -static -lc++abi" CACHE STRING "")
 set(CMAKE_SHARED_LINKER_FLAGS "--unwindlib=libunwind" CACHE STRING "")
 
-# Set the default target triple to match the host.
-# TODO: passing in the value of $(clang -print-multiarch) causes failures.
-# It seems that alpine clang's default target triple is x86_64-linux-gnu.
-# Perhaps missing alpine in the triple causes some incompatibility?
-set(LLVM_DEFAULT_TARGET_TRIPLE x86_64-alpine-linux-musl CACHE STRING "")
-
 # Use libc++ from stage1.
 # TODO: is CMAKE_CXX_FLAGS still necessary if this is set?
 set(LLVM_ENABLE_LIBCXX ON CACHE BOOL "")
@@ -49,9 +43,9 @@ set(LLVM_ENABLE_ZLIB "FORCE_ON" CACHE STRING "")
 # This is necessary to statically link libc++ into clang.
 set(LLVM_STATIC_LINK_CXX_STDLIB "1" CACHE STRING "")
 
-# Just build support for x86 for now.
-# TODO: change this to host when adding more stages.
-set(LLVM_TARGETS_TO_BUILD "X86;" CACHE STRING "")
+# Just build stage2 to target the host. It's not the end product, so it won't
+# be able to target all of the kernel targets we can build.
+set(LLVM_TARGETS_TO_BUILD "host;" CACHE STRING "")
 
 # Set clang's default --stdlib= to libc++.
 set(CLANG_DEFAULT_CXX_STDLIB "libc++" CACHE STRING "")

--- a/llvm-project/stage3.cmake
+++ b/llvm-project/stage3.cmake
@@ -15,12 +15,6 @@ set(CMAKE_C_FLAGS "--sysroot=/sysroot" CACHE STRING "")
 # Statically link resulting executable.
 set(CMAKE_EXE_LINKER_FLAGS "-static -lc++abi" CACHE STRING "")
 
-# Set the default target triple to match the host.
-# TODO: passing in the value of $(clang -print-target-triple) causes failures.
-# It seems that alpine clang's default target triple is x86_64-linux-gnu.
-# Perhaps missing alpine in the triple causes some incompatibility?
-set(LLVM_DEFAULT_TARGET_TRIPLE x86_64-alpine-linux-musl CACHE STRING "")
-
 # Use libc++ from stage2.
 # TODO: is CMAKE_CXX_FLAGS still necessary if this is set?
 set(LLVM_ENABLE_LIBCXX ON CACHE BOOL "")
@@ -38,7 +32,8 @@ set(LLVM_ENABLE_ZLIB "FORCE_ON" CACHE STRING "")
 # This is necessary to statically link libc++ into clang.
 set(LLVM_STATIC_LINK_CXX_STDLIB "1" CACHE STRING "")
 
-# Just build support for x86 for now.
+# Just build stage3 to target the host. It's not the end product, so it won't
+# be able to target all of the kernel targets we can build.
 set(LLVM_TARGETS_TO_BUILD "host;" CACHE STRING "")
 
 # Set clang's default --stdlib= to libc++.


### PR DESCRIPTION
Now that we have self-hosted runners, we can actually build on an arm64 machine. This removes all the "x86-isms" in the Docker and CMake files and wires up GitHub Actions to build on both arm64 and x86_64.

A recent successful run: https://github.com/nathanchance/containers/actions/runs/2464883356

I have verified that epoch one through three works as expected locally.
