### PR TITLE
Fix tags and update Makefile workflow to match

### DIFF
--- a/.github/workflows/llvm-project-epoch-one.yml
+++ b/.github/workflows/llvm-project-epoch-one.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: arm64
+          - arch: aarch64
             os: [self-hosted, arm64]
             platforms: linux/arm64
           - arch: x86_64
@@ -25,7 +25,7 @@ jobs:
           arch: ${{ matrix.arch }}
           file: Dockerfile.epoch1
           platforms: ${{ matrix.platforms }}
-          tags: ghcr.io/clangbuiltlinux/llvm-project:stage2
+          tags: ghcr.io/clangbuiltlinux/llvm-project:stage2-${{ matrix.arch }}
 
       - name: Login to ghcr.io
         if: ${{ github.repository_owner == 'ClangBuiltLinux' && github.event_name != 'pull_request' && github.ref_name == 'main' }}
@@ -38,4 +38,4 @@ jobs:
       - name: Push image to ghcr.io
         if: ${{ github.repository_owner == 'ClangBuiltLinux' && github.event_name != 'pull_request' && github.ref_name == 'main' }}
         run: |
-          docker push ghcr.io/clangbuiltlinux/llvm-project:stage2
+          docker push ghcr.io/clangbuiltlinux/llvm-project:stage2-${{ matrix.arch }}

--- a/.github/workflows/llvm-project-epoch-three.yml
+++ b/.github/workflows/llvm-project-epoch-three.yml
@@ -22,8 +22,9 @@ jobs:
       - name: Build and test llvm-project
         uses: ./.github/actions/build-test-llvm-project
         with:
+          arch: ${{ matrix.arch }}
           file: Dockerfile.epoch3
-          platforms: linux/amd64
+          platforms: ${{ matrix.platforms }}
           tags: ghcr.io/clangbuiltlinux/llvm-project:stage3
 
       - name: Login to ghcr.io

--- a/.github/workflows/llvm-project-epoch-three.yml
+++ b/.github/workflows/llvm-project-epoch-three.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: arm64
+          - arch: aarch64
             os: [self-hosted, arm64]
             platforms: linux/arm64
           - arch: x86_64
@@ -23,9 +23,10 @@ jobs:
         uses: ./.github/actions/build-test-llvm-project
         with:
           arch: ${{ matrix.arch }}
+          build-args: BASE=ghcr.io/clangbuiltlinux/llvm-project:stage2-${{ matrix.arch }}
           file: Dockerfile.epoch3
           platforms: ${{ matrix.platforms }}
-          tags: ghcr.io/clangbuiltlinux/llvm-project:stage3
+          tags: ghcr.io/clangbuiltlinux/llvm-project:stage3-${{ matrix.arch }}
 
       - name: Login to ghcr.io
         if: ${{ github.repository_owner == 'ClangBuiltLinux' && github.event_name != 'pull_request' && github.ref_name == 'main' }}
@@ -38,4 +39,4 @@ jobs:
       - name: Push image to ghcr.io
         if: ${{ github.repository_owner == 'ClangBuiltLinux' && github.event_name != 'pull_request' && github.ref_name == 'main' }}
         run: |
-          docker push ghcr.io/clangbuiltlinux/llvm-project:stage3
+          docker push ghcr.io/clangbuiltlinux/llvm-project:stage3-${{ matrix.arch }}

--- a/.github/workflows/llvm-project-epoch-two.yml
+++ b/.github/workflows/llvm-project-epoch-two.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: arm64
+          - arch: aarch64
             os: [self-hosted, arm64]
             platforms: linux/arm64
           - arch: x86_64
@@ -23,9 +23,10 @@ jobs:
         uses: ./.github/actions/build-test-llvm-project
         with:
           arch: ${{ matrix.arch }}
+          build-args: BASE=ghcr.io/clangbuiltlinux/llvm-project:stage2-${{ matrix.arch }}
           file: Dockerfile.epoch2
           platforms: ${{ matrix.platforms }}
-          tags: ghcr.io/clangbuiltlinux/llvm-project:stage2
+          tags: ghcr.io/clangbuiltlinux/llvm-project:stage2-${{ matrix.arch }}
 
       - name: Login to ghcr.io
         if: ${{ github.repository_owner == 'ClangBuiltLinux' && github.event_name != 'pull_request' && github.ref_name == 'main' }}
@@ -38,4 +39,4 @@ jobs:
       - name: Push image to ghcr.io
         if: ${{ github.repository_owner == 'ClangBuiltLinux' && github.event_name != 'pull_request' && github.ref_name == 'main' }}
         run: |
-          docker push ghcr.io/clangbuiltlinux/llvm-project:stage2
+          docker push ghcr.io/clangbuiltlinux/llvm-project:stage2-${{ matrix.arch }}

--- a/ci/test-clang.sh
+++ b/ci/test-clang.sh
@@ -10,13 +10,13 @@ toolchain=$rootdir/toolchain
 
 # Pull toolchain out of container
 echo "[+] Downloading toolchain from container"
-"${docker:=docker}" create --name llvm-project "$1"
+"${DOCKER:=docker}" create --name llvm-project "$1"
 mkdir "$toolchain"
-"$docker" cp llvm-project:/usr/local/bin "$toolchain"
-"$docker" cp llvm-project:/usr/local/include "$toolchain"
-"$docker" cp llvm-project:/usr/local/lib "$toolchain"
+"$DOCKER" cp llvm-project:/usr/local/bin "$toolchain"
+"$DOCKER" cp llvm-project:/usr/local/include "$toolchain"
+"$DOCKER" cp llvm-project:/usr/local/lib "$toolchain"
 echo "[+] Cleaning up container"
-"$docker" rm llvm-project
+"$DOCKER" rm llvm-project
 
 # Test toolchain in Docker images so that the environment is consistent,
 # regardless of runners.
@@ -27,9 +27,9 @@ docker_images=(
 [[ $(uname -m) = "x86_64" ]] && docker_images+=(docker.io/archlinux:latest)
 for docker_image in "${docker_images[@]}"; do
     echo "[+] Updating '$docker_image'"
-    "$docker" pull "$docker_image"
+    "$DOCKER" pull "$docker_image"
     echo "[+] Testing clang in '$docker_image' container"
-    "$docker" run \
+    "$DOCKER" run \
         --rm \
         --volume "$rootdir":/repo:ro,z \
         "$docker_image" \

--- a/llvm-project/Dockerfile.epoch2
+++ b/llvm-project/Dockerfile.epoch2
@@ -1,10 +1,12 @@
+ARG BASE
+
 FROM docker.io/alpine:edge AS source
 RUN wget --no-clobber \
   https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.1/llvm-project-14.0.1.src.tar.xz
 
 ### START STAGE2
 
-FROM ghcr.io/clangbuiltlinux/llvm-project:stage2 as prev_epoch
+FROM ${BASE} as prev_epoch
 FROM docker.io/alpine:edge as stage_two
 
 COPY --from=prev_epoch /usr/local/bin /usr/local/bin

--- a/llvm-project/Dockerfile.epoch3
+++ b/llvm-project/Dockerfile.epoch3
@@ -1,4 +1,4 @@
-ARG base=ghcr.io/clangbuiltlinux/llvm-project:stage2
+ARG BASE
 
 FROM docker.io/alpine:edge AS source
 RUN wget --no-verbose https://git.kernel.org/torvalds/t/linux-5.18-rc6.tar.gz
@@ -6,7 +6,7 @@ RUN wget --no-verbose https://musl.libc.org/releases/musl-1.2.3.tar.gz
 RUN wget --no-verbose https://zlib.net/zlib-1.2.12.tar.gz
 RUN wget --no-verbose https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.1/llvm-project-14.0.1.src.tar.xz
 
-FROM ${base} AS stage2
+FROM ${BASE} AS stage2
 FROM docker.io/alpine:edge AS stage3
 
 ### BEGIN STAGE3

--- a/llvm-project/Makefile
+++ b/llvm-project/Makefile
@@ -1,3 +1,5 @@
+DOCKER ?= docker
+
 .DEFAULT_GOAL := clang
 
 %.svg: %.dot
@@ -8,7 +10,7 @@ dotfiles: stage2.svg stage1.svg
 .PHONY: clang
 TAG ?= clangbuiltlinux/llvm-project:latest
 clang:
-	docker build --tag $(TAG) .
-	docker rm llvm-project || true
-	docker create --name llvm-project $(TAG)
-	docker cp llvm-project:/usr/local/bin/clang-14 clang
+	$(DOCKER) build --tag $(TAG) .
+	$(DOCKER) rm llvm-project || true
+	$(DOCKER) create --name llvm-project $(TAG)
+	$(DOCKER) cp llvm-project:/usr/local/bin/clang-14 clang

--- a/llvm-project/Makefile
+++ b/llvm-project/Makefile
@@ -1,4 +1,6 @@
 DOCKER ?= docker
+HOST_ARCH := $(shell uname -m)
+IMAGE ?= ghcr.io/clangbuiltlinux/llvm-project
 
 .DEFAULT_GOAL := clang
 
@@ -7,10 +9,29 @@ DOCKER ?= docker
 
 dotfiles: stage2.svg stage1.svg
 
-.PHONY: clang
-TAG ?= clangbuiltlinux/llvm-project:latest
-clang:
-	$(DOCKER) build --tag $(TAG) .
+.PHONY: clang epoch1 epoch2 epoch3
+
+# Argument 1: epoch# (e.g., epoch1; should match the suffix of the Dockerfile)
+# Argument 2: Tag (e.g., ghcr.io/clangbuiltlinux/llvm-project:stage2-x86_64)
+# Argument 3 (optional): Tag of previous epoch to build current epoch from.
+epoch_cmd = \
+	$(DOCKER) build \
+		$(if $(3),--build-arg BASE=$(3)) \
+		--file Dockerfile.$(1) \
+		--tag $(2) \
+		. && \
+	bash ../ci/test-clang.sh $(2)
+
+epoch1:
+	$(call epoch_cmd,$@,$(IMAGE):stage2-$(HOST_ARCH))
+
+epoch2:
+	$(call epoch_cmd,$@,$(IMAGE):stage2-$(HOST_ARCH),$(IMAGE):stage2-$(HOST_ARCH))
+
+epoch3:
+	$(call epoch_cmd,$@,$(IMAGE):stage3-$(HOST_ARCH),$(IMAGE):stage2-$(HOST_ARCH))
+
+clang: epoch3
 	$(DOCKER) rm llvm-project || true
-	$(DOCKER) create --name llvm-project $(TAG)
+	$(DOCKER) create --name llvm-project $(IMAGE):stage3-$(HOST_ARCH)
 	$(DOCKER) cp llvm-project:/usr/local/bin/clang-14 clang

--- a/llvm-project/README.md
+++ b/llvm-project/README.md
@@ -59,11 +59,11 @@ goal for stage 3.
 
 To play with this image, you can run:
 ```sh
-$ docker run -it ghcr.io/clangbuiltlinux/llvm-project:stage2 ash
+$ docker run -it ghcr.io/clangbuiltlinux/llvm-project:stage2-$(uname -m) ash
 ```
 To copy the statically linked clang binary out of it, you can run:
 ```
-$ docker create --name temp ghcr.io/clangbuiltlinux/llvm-project:stage2
+$ docker create --name temp ghcr.io/clangbuiltlinux/llvm-project:stage2-$(uname -m)
 $ docker cp temp:/usr/local/bin/clang-14 clang
 $ docker rm temp
 ```


### PR DESCRIPTION
We currently use the same tag for each architecture, which does not work without [a Docker manifest](https://docs.docker.com/engine/reference/commandline/manifest/). Even with a manifest, we need to have separate architecture specific tags, so this PR just cuts us over to those and wires them up in both GitHub Actions and the existing `Makefile` to make it easy to test locally. See the individual commits for the logic behind each change.
