### PR TITLE
github: build-test-llvm-project: Add build-args

### DIFF
--- a/.github/actions/build-test-llvm-project/action.yml
+++ b/.github/actions/build-test-llvm-project/action.yml
@@ -5,6 +5,10 @@ inputs:
   arch:
     description: Architecture to build containers for
     required: true
+  build-args:
+    description: List of build arguments to pass along to Docker
+    required: false
+    default: NONE=none
   file:
     description: Dockerfile to build the container from
     required: true
@@ -24,6 +28,7 @@ runs:
     - name: Build llvm-project
       uses: docker/build-push-action@v3
       with:
+        build-args: ${{ inputs.build-args }}
         context: ./llvm-project
         file: ./llvm-project/${{ inputs.file }}
         load: true


### PR DESCRIPTION
We need this now after commit dcc15cd ("github: Make tag specific to
architecture"). Unfortunately, I don't see a clear way to pass in
build-args conditionally to docker/build-push-action, so we provide a
dummy list of arguments that can be used when no build arguments are
needed (i.e., for epoch one).
