### PR TITLE
test-clang.sh: use unsecure seccomp to work around runc issue

### DIFF
--- a/ci/test-clang.sh
+++ b/ci/test-clang.sh
@@ -31,6 +31,7 @@ for docker_image in "${docker_images[@]}"; do
     echo "[+] Testing clang in '$docker_image' container"
     "$DOCKER" run \
         --rm \
+        --security-opt seccomp=unconfined \
         --volume "$rootdir":/repo:ro,z \
         "$docker_image" \
         bash /repo/ci/test-clang-docker.sh

--- a/llvm-project/Makefile
+++ b/llvm-project/Makefile
@@ -35,5 +35,5 @@ clang: epoch3
 	$(DOCKER) create --name llvm-project $(IMAGE):stage3-$(HOST_ARCH)
 	$(DOCKER) cp llvm-project:/usr/local/bin/clang-14 clang
 
-test: clang
+test: epoch3
 	bash ../ci/test-clang.sh $(IMAGE):stage3-$(HOST_ARCH)

--- a/llvm-project/Makefile
+++ b/llvm-project/Makefile
@@ -19,8 +19,7 @@ epoch_cmd = \
 		$(if $(3),--build-arg BASE=$(3)) \
 		--file Dockerfile.$(1) \
 		--tag $(2) \
-		. && \
-	bash ../ci/test-clang.sh $(2)
+		.
 
 epoch1:
 	$(call epoch_cmd,$@,$(IMAGE):stage2-$(HOST_ARCH))
@@ -35,3 +34,6 @@ clang: epoch3
 	$(DOCKER) rm llvm-project || true
 	$(DOCKER) create --name llvm-project $(IMAGE):stage3-$(HOST_ARCH)
 	$(DOCKER) cp llvm-project:/usr/local/bin/clang-14 clang
+
+test: clang
+	bash ../ci/test-clang.sh $(IMAGE):stage3-$(HOST_ARCH)


### PR DESCRIPTION
Otherwise we observe the error:

[+] Updating OS
Error: Failed to download metadata for repo 'fedora': Cannot prepare
internal mirrorlist: Curl error (6): Couldn't resolve host name for
https://mirrors.fedoraproject.org/metalink?repo=fedora-36&arch=x86_64
[getaddrinfo() thread failed to start]

Link: https://pascalroeleven.nl/2021/09/09/ubuntu-21-10-and-fedora-35-in-docker/
Link: https://bugzilla.redhat.com/show_bug.cgi?id=2009047
Fixes #34