### PR TITLE
Create and link against libllvmlibc-sparse

### DIFF
--- a/llvm-project/0001-libc-Fix-build-when-__FE_DENORM-is-defined.patch
+++ b/llvm-project/0001-libc-Fix-build-when-__FE_DENORM-is-defined.patch
@@ -1,0 +1,49 @@
+From 122da690b39a67cd6e6bce4b9ad3ac1470cc1ed5 Mon Sep 17 00:00:00 2001
+From: Alex Brachet <abrachet@google.com>
+Date: Wed, 8 Jun 2022 16:21:53 +0000
+Subject: [PATCH] [libc] Fix build when __FE_DENORM is defined
+
+[nd: drop hunk that doesn't apply to 14.0.1 due to missing
+  commit 805899e68a83 ("[libc] Change FEnv to use MXCSR as source of truth")]
+
+Differential revision: https://reviews.llvm.org/D127222
+---
+ libc/src/__support/FPUtil/x86_64/FEnvImpl.h | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/libc/src/__support/FPUtil/x86_64/FEnvImpl.h b/libc/src/__support/FPUtil/x86_64/FEnvImpl.h
+index 846996ec93af..6bac3e9e6a0f 100644
+--- a/libc/src/__support/FPUtil/x86_64/FEnvImpl.h
++++ b/libc/src/__support/FPUtil/x86_64/FEnvImpl.h
+@@ -73,7 +73,7 @@ static inline uint16_t get_status_value_for_except(int excepts) {
+   // bit flags in the control registers.
+   return (excepts & FE_INVALID ? ExceptionFlags::INVALID : 0) |
+ #ifdef __FE_DENORM
+-         (excepts & __FE_DENORM ? ExceptionFlags::Denormal : 0) |
++         (excepts & __FE_DENORM ? ExceptionFlags::DENORMAL : 0) |
+ #endif // __FE_DENORM
+          (excepts & FE_DIVBYZERO ? ExceptionFlags::DIV_BY_ZERO : 0) |
+          (excepts & FE_OVERFLOW ? ExceptionFlags::OVERFLOW : 0) |
+@@ -84,7 +84,7 @@ static inline uint16_t get_status_value_for_except(int excepts) {
+ static inline int exception_status_to_macro(uint16_t status) {
+   return (status & ExceptionFlags::INVALID ? FE_INVALID : 0) |
+ #ifdef __FE_DENORM
+-         (status & ExceptionFlags::Denormal ? __FE_DENORM : 0) |
++         (status & ExceptionFlags::DENORMAL ? __FE_DENORM : 0) |
+ #endif // __FE_DENORM
+          (status & ExceptionFlags::DIV_BY_ZERO ? FE_DIVBYZERO : 0) |
+          (status & ExceptionFlags::OVERFLOW ? FE_OVERFLOW : 0) |
+@@ -273,8 +273,8 @@ static inline int raise_except(int excepts) {
+   if (status_value & internal::ExceptionFlags::INEXACT)
+     raise_helper(internal::ExceptionFlags::INEXACT);
+ #ifdef __FE_DENORM
+-  if (statusValue & internal::ExceptionFlags::Denormal) {
+-    raiseHelper(internal::ExceptionFlags::Denormal);
++  if (status_value & internal::ExceptionFlags::DENORMAL) {
++    raise_helper(internal::ExceptionFlags::DENORMAL);
+   }
+ #endif // __FE_DENORM
+ 
+-- 
+2.37.0.144.g8ac04bfd2-goog
+

--- a/llvm-project/Dockerfile.epoch3
+++ b/llvm-project/Dockerfile.epoch3
@@ -80,6 +80,11 @@ RUN tar xf llvm-project-14.0.1.src.tar.xz && \
   mv llvm-project-14.0.1.src llvm-project
 RUN apk add cmake ninja python3
 COPY stage3.cmake llvm-project/.
+COPY 0001-libc-Fix-build-when-__FE_DENORM-is-defined.patch llvm-project/.
+RUN apk add patch
+RUN cd llvm-project && \
+  patch -p1 < 0001-libc-Fix-build-when-__FE_DENORM-is-defined.patch
+RUN apk del patch
 ARG LLVM_BUILD_DIR=llvm-project/llvm/build
 RUN cmake \
   -B ${LLVM_BUILD_DIR} \
@@ -87,6 +92,22 @@ RUN cmake \
   -D LLVM_DEFAULT_TARGET_TRIPLE=$(clang -print-target-triple) \
   -S llvm-project/llvm \
   -G Ninja
+
+RUN ninja -C ${LLVM_BUILD_DIR} llvmlibc
+COPY build_sparse_libc.sh ${LLVM_BUILD_DIR}/.
+RUN cd ${LLVM_BUILD_DIR} && \
+  ./build_sparse_libc.sh && \
+  mv libllvmlibc-sparse.a /sysroot/usr/lib/.
+
+RUN cmake \
+  -B ${LLVM_BUILD_DIR} \
+  -C llvm-project/stage3.cmake \
+  -D LLVM_DEFAULT_TARGET_TRIPLE=$(clang -print-target-triple) \
+  -S llvm-project/llvm \
+  -D CMAKE_EXE_LINKER_FLAGS="-static -lc++abi -ljemalloc -lllvmlibc-sparse -Wl,--allow-multiple-definition" \
+  -G Ninja
+#RUN ninja -C ${LLVM_BUILD_DIR} llvm-tblgen
+#RUN llvm-objdump -dr --disassemble-symbols=strlen llvm-project/llvm/build/bin/llvm-tblgen
 RUN ninja -C ${LLVM_BUILD_DIR} install-clang install-lld
 RUN ninja -C ${LLVM_BUILD_DIR} install-clang-resource-headers
 RUN ninja -C ${LLVM_BUILD_DIR} \

--- a/llvm-project/Dockerfile.epoch3
+++ b/llvm-project/Dockerfile.epoch3
@@ -106,8 +106,6 @@ RUN cmake \
   -S llvm-project/llvm \
   -D CMAKE_EXE_LINKER_FLAGS="-static -lc++abi -ljemalloc -lllvmlibc-sparse -Wl,--allow-multiple-definition" \
   -G Ninja
-#RUN ninja -C ${LLVM_BUILD_DIR} llvm-tblgen
-#RUN llvm-objdump -dr --disassemble-symbols=strlen llvm-project/llvm/build/bin/llvm-tblgen
 RUN ninja -C ${LLVM_BUILD_DIR} install-clang install-lld
 RUN ninja -C ${LLVM_BUILD_DIR} install-clang-resource-headers
 RUN ninja -C ${LLVM_BUILD_DIR} \

--- a/llvm-project/build_sparse_libc.sh
+++ b/llvm-project/build_sparse_libc.sh
@@ -2,7 +2,7 @@
 
 LLVM_LIBC=$(find . -name libllvmlibc.a)
 for i in strlen memcmp memset memcpy; do
-  llvm-ar x ${LLVM_LIBC} $i.cpp.o
+  llvm-ar x "${LLVM_LIBC}" $i.cpp.o
 done
 rm -f libllvmlibc-sparse.a
 llvm-ar qc libllvmlibc-sparse.a memcmp.cpp.o memcpy.cpp.o memset.cpp.o strlen.cpp.o

--- a/llvm-project/build_sparse_libc.sh
+++ b/llvm-project/build_sparse_libc.sh
@@ -2,7 +2,7 @@
 
 LLVM_LIBC=$(find . -name libllvmlibc.a)
 for i in strlen memcmp memset memcpy; do
-  llvm-ar x "${LLVM_LIBC}" $i.cpp.o
+    llvm-ar x "${LLVM_LIBC}" $i.cpp.o
 done
 rm -f libllvmlibc-sparse.a
 llvm-ar qc libllvmlibc-sparse.a memcmp.cpp.o memcpy.cpp.o memset.cpp.o strlen.cpp.o

--- a/llvm-project/build_sparse_libc.sh
+++ b/llvm-project/build_sparse_libc.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+LLVM_LIBC=$(find . -name libllvmlibc.a)
+for i in strlen memcmp memset memcpy; do
+  llvm-ar x ${LLVM_LIBC} $i.cpp.o
+done
+rm -f libllvmlibc-sparse.a
+llvm-ar qc libllvmlibc-sparse.a memcmp.cpp.o memcpy.cpp.o memset.cpp.o strlen.cpp.o

--- a/llvm-project/stage3.cmake
+++ b/llvm-project/stage3.cmake
@@ -46,7 +46,7 @@ set(LLVM_ENABLE_LIBCXX ON CACHE BOOL "")
 # Use lld from stage2.
 set(LLVM_ENABLE_LLD ON CACHE BOOL "")
 
-# Build clang, lld, and compiler-rt.
+# Build clang, lld, compiler-rt, and libc.
 set(LLVM_ENABLE_PROJECTS "clang;lld;compiler-rt;libc" CACHE STRING "")
 
 # FORCE_ON causes the build to fail if zlib is not found in the environment

--- a/llvm-project/stage3.cmake
+++ b/llvm-project/stage3.cmake
@@ -47,7 +47,7 @@ set(LLVM_ENABLE_LIBCXX ON CACHE BOOL "")
 set(LLVM_ENABLE_LLD ON CACHE BOOL "")
 
 # Build clang, lld, and compiler-rt.
-set(LLVM_ENABLE_PROJECTS "clang;lld;compiler-rt" CACHE STRING "")
+set(LLVM_ENABLE_PROJECTS "clang;lld;compiler-rt;libc" CACHE STRING "")
 
 # FORCE_ON causes the build to fail if zlib is not found in the environment
 # during configuration, rather than much later during link.


### PR DESCRIPTION
Using musl solved our static linking woes, but introduced performance
regressions. Specifically, calls to memset, memcpy, memcmp, and strlen
became more noticeable in profiles.

Build llvmlibc, extract the .o files from the .a for those 4, repack
them in a new .a, then link against that.

llvmlibc's strlen isn't measurably better, but the author is aware and
interested in fixing.

See
https://github.com/ClangBuiltLinux/containers/issues/39#issuecomment-1181008035
for performance measurements.

Fixes #39