### PR TITLE
qemu: Install binutils

### DIFF
--- a/qemu/Dockerfile
+++ b/qemu/Dockerfile
@@ -2,6 +2,7 @@ FROM docker.io/archlinux:base
 
 RUN pacman -Syyu --noconfirm && \
     pacman -S --noconfirm \
+        binutils \
         git \
         python \
         python-yaml \


### PR DESCRIPTION
We needs `strings` for `boot-qemu.py`.
