### PR TITLE
qemu: Temporarily switch to testing repo for updated QEMU packages

### DIFF
--- a/qemu/Dockerfile
+++ b/qemu/Dockerfile
@@ -1,6 +1,7 @@
 FROM docker.io/archlinux:base
 
-RUN pacman -Syyu --noconfirm && \
+RUN sed -i "/\[testing\]/,/Include/"'s/^#//' /etc/pacman.conf && \
+    pacman -Syyu --noconfirm && \
     pacman -S --noconfirm \
         binutils \
         git \


### PR DESCRIPTION
A bug in Arch Linux's QEMU packaging caused the s390 firmware files to
be exclude in the upgrade to 7.1.0-6. This has been resolved with
7.1.0-8, which may not be in the stable repositories for a bit, as
7.1.0-7 was a rebuild against a new libbpf.

To get access to the fixed version now, enable the testing repository.
This should have a minimal impact to continuous integration, as none of
the other packages have a testing version, and this can just be reverted
directly when the fixed QEMU packages are available in the stable
repository.

Link: https://bugs.archlinux.org/task/76092
Link: https://github.com/archlinux/svntogit-packages/commit/5a1a76efc1f48365b25ccee53fd9e7fb26e00b96
Link: https://github.com/archlinux/svntogit-packages/commit/f42375d75ce1c8ebb992d51ab6343e8baa67bd45
