### PR TITLE
Revert "qemu: Temporarily switch to testing repo for updated QEMU packages"

### DIFF
--- a/qemu/Dockerfile
+++ b/qemu/Dockerfile
@@ -1,7 +1,6 @@
 FROM docker.io/archlinux:base
 
-RUN sed -i "/\[testing\]/,/Include/"'s/^#//' /etc/pacman.conf && \
-    pacman -Syyu --noconfirm && \
+RUN pacman -Syyu --noconfirm && \
     pacman -S --noconfirm \
         binutils \
         git \


### PR DESCRIPTION
This reverts commit 879be368a87b7c1605ebba2b143a2ca4562d0512.

7.1.0-8 is now in the stable repos:

Link: https://github.com/archlinux/svntogit-packages/commit/382d5bd2428e68c49d39fdd2ef7d7aca5ea76b74
