### PR TITLE
workflows: docker: Switch to GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Set variables
         id: variables
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H-%M')"
+        run: echo "date=$(date +'%Y-%m-%d-%H-%M')" >> $GITHUB_OUTPUT
 
       - name: Build
         uses: docker/build-push-action@v3


### PR DESCRIPTION
set-output is deprecated:

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
