### PR TITLE
qemu: Install qemu-system-loongarch64

### DIFF
--- a/qemu/Dockerfile
+++ b/qemu/Dockerfile
@@ -8,6 +8,7 @@ RUN pacman -Syyu --noconfirm && \
         python-yaml \
         qemu-system-aarch64 \
         qemu-system-arm \
+        qemu-system-loongarch64 \
         qemu-system-mips \
         qemu-system-ppc \
         qemu-system-riscv \


### PR DESCRIPTION
This is needed for running LoongArch kernels in CI.
