### PR TITLE
qemu: Install qemu-system-sparc

### DIFF
--- a/qemu/Dockerfile
+++ b/qemu/Dockerfile
@@ -13,5 +13,6 @@ RUN pacman -Syyu --noconfirm && \
         qemu-system-ppc \
         qemu-system-riscv \
         qemu-system-s390x \
+        qemu-system-sparc \
         qemu-system-x86 \
         zstd


### PR DESCRIPTION
This is needed to support booting sparc kernels in CI.
